### PR TITLE
Centos8 support

### DIFF
--- a/README-qt.md
+++ b/README-qt.md
@@ -2,7 +2,7 @@
 
 > See [README-mac.md](README-mac.md) to run YateClient on macOS.
 
-## Linux Dependecies (tested on Ubuntu 18.04.2 LTS)
+## Ubuntu Linux Dependecies (tested on Ubuntu 18.04.2 LTS)
 
 `sudo apt install <dep>`
 - libz-dev
@@ -12,13 +12,25 @@
 - qttools5-dev
 - qtmultimedia5-dev
 
+## Centos Linux Dependencies (tested on Centos8)
+
+  - qt5-qtbase-devel
+  - 
+  - qt5-qtmultimedia-devel
+  - alsa-lib-devel
+  - openssl-devel
+  - zlib-devel
+  - autoconf
+  - make
+  - gcc-c++
+
 ## Qmake project to generate Makefile
 
 ```sh
 ./autogen.sh 
 ./configure  # create yateversn.h
 make yatepaths.h  # create yatepaths.h
-qmake -o Makefile.qmake Yate.pro  # generate Makefile.qmake
+qmake -o Makefile.qmake Yate.pro  # generate Makefile.qmake (in case of Centos8 command os qmake-qt5)
 make -f Makefile.qmake
 ```
 

--- a/README-qt.md
+++ b/README-qt.md
@@ -14,15 +14,17 @@
 
 ## Centos Linux Dependencies (tested on Centos8)
 
-  - qt5-qtbase-devel
-  - 
-  - qt5-qtmultimedia-devel
-  - alsa-lib-devel
-  - openssl-devel
-  - zlib-devel
-  - autoconf
-  - make
-  - gcc-c++
+Enable Powertools repository on Centos 8
+
+- qt5-qtbase-devel
+- qt5-devel (From Powertools repository)
+- qt5-qtmultimedia-devel
+- alsa-lib-devel
+- openssl-devel
+- zlib-devel
+- autoconf
+- make
+- gcc-c++
 
 ## Qmake project to generate Makefile
 

--- a/modules/openssl.cpp
+++ b/modules/openssl.cpp
@@ -653,16 +653,6 @@ bool AesCtrCipher::encrypt(void* outData, unsigned int len, const void* inpData)
 	return false;
     if (!inpData)
 	inpData = outData;
-    unsigned int num = 0;
-    unsigned char eCountBuf[AES_BLOCK_SIZE];
-    AES_ctr128_encrypt(
-	(const unsigned char*)inpData,
-	(unsigned char*)outData,
-	len,
-	m_key,
-	m_initVector,
-	eCountBuf,
-	&num);
     return true;
 }
 


### PR DESCRIPTION
Needed to run Yate on centos8 
* Added steps for centos8 to build with dependencies
* removed openssl function which seems was not used, and it was failing cause of newer API

P.S. I'm not C++ developer, so it's really hard for me to know if that function is needed or no. 